### PR TITLE
fixed decoding, still broken wip though

### DIFF
--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1576,6 +1576,9 @@ func mvccScanInternal(
 				log.Infof(ctx, "executing filter on %+v", kv)
 				passes := filter(kv)
 				log.Info(ctx, "executed filter; passes=%t", passes)
+				if !passes {
+					return false, nil
+				}
 			}
 
 			if noValues {


### PR DESCRIPTION
Current state is what seems to be an infinite run (running `SELECT * FROM tpch.lineitem where l_quantity = 17` with 120086 results that usually runs in ~37s. There must be something in the fetcher's exit conditions that we aren't triggering but I don't know what.