### PR TITLE
rpc: run grpc interceptors for local RPCs

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -110,6 +110,7 @@ go_test(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -313,11 +314,83 @@ func TestInternalServerAddress(t *testing.T) {
 	serverCtx.NodeID.Set(context.Background(), 1)
 
 	internal := &internalServer{}
-	serverCtx.SetLocalInternalServer(internal)
+	serverCtx.SetLocalInternalServer(internal, ServerInterceptorInfo{})
 
-	exp := internalClientAdapter{internal}
-	if ic := serverCtx.GetLocalInternalClientForAddr(serverCtx.Config.AdvertiseAddr, 1); ic != exp {
-		t.Fatalf("expected %+v, got %+v", exp, ic)
+	ic := serverCtx.GetLocalInternalClientForAddr(serverCtx.Config.AdvertiseAddr, 1)
+	lic, ok := ic.(*internalClientAdapter)
+	require.True(t, ok)
+	require.Equal(t, internal, lic.server)
+}
+
+// Test that the internalClientAdapter runs the gRPC server interceptors.
+func TestInternalClientAdapterRunsServerInterceptors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	stopper.SetTracer(tracing.NewTracer())
+
+	// Can't be zero because that'd be an empty offset.
+	clock := hlc.NewClock(timeutil.Unix(0, 1).UnixNano, time.Nanosecond)
+
+	serverCtx := newTestContext(uuid.MakeV4(), clock, stopper)
+	serverCtx.Config.Addr = "127.0.0.1:9999"
+	serverCtx.Config.AdvertiseAddr = "127.0.0.1:8888"
+	serverCtx.NodeID.Set(context.Background(), 1)
+
+	_, interceptors := NewServerEx(serverCtx)
+
+	// Pile on one more interceptor to make sure it's called.
+	interceptorCalled := false
+	interceptors.UnaryInterceptors = append(interceptors.UnaryInterceptors, func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		interceptorCalled = true
+		return handler(ctx, req)
+	})
+
+	internal := &internalServer{}
+	serverCtx.SetLocalInternalServer(internal, interceptors)
+	ic := serverCtx.GetLocalInternalClientForAddr(serverCtx.Config.AdvertiseAddr, 1)
+	lic, ok := ic.(*internalClientAdapter)
+	require.True(t, ok)
+	require.Equal(t, internal, lic.server)
+
+	ba := &roachpb.BatchRequest{}
+	_, err := lic.Batch(ctx, ba)
+	require.NoError(t, err)
+	require.True(t, interceptorCalled)
+}
+
+func BenchmarkInternalClientAdapter(b *testing.B) {
+	ctx := context.Background()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	// Can't be zero because that'd be an empty offset.
+	clock := hlc.NewClock(timeutil.Unix(0, 1).UnixNano, time.Nanosecond)
+
+	serverCtx := newTestContext(uuid.MakeV4(), clock, stopper)
+	serverCtx.Config.Addr = "127.0.0.1:9999"
+	serverCtx.Config.AdvertiseAddr = "127.0.0.1:8888"
+	serverCtx.NodeID.Set(context.Background(), 1)
+
+	_, interceptors := NewServerEx(serverCtx)
+
+	internal := &internalServer{}
+	serverCtx.SetLocalInternalServer(internal, interceptors)
+	ic := serverCtx.GetLocalInternalClientForAddr(serverCtx.Config.AdvertiseAddr, 1)
+	lic, ok := ic.(*internalClientAdapter)
+	require.True(b, ok)
+	require.Equal(b, internal, lic.server)
+	ba := &roachpb.BatchRequest{}
+	_, err := lic.Batch(ctx, ba)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = lic.Batch(ctx, ba)
 	}
 }
 
@@ -480,7 +553,7 @@ func TestHeartbeatHealth(t *testing.T) {
 	// Ensure that the local Addr returns ErrNotHeartbeated without having dialed
 	// a connection but the local AdvertiseAddr successfully returns no error when
 	// an internal server has been registered.
-	clientCtx.SetLocalInternalServer(&internalServer{})
+	clientCtx.SetLocalInternalServer(&internalServer{}, ServerInterceptorInfo{})
 
 	if err := clientCtx.TestingConnHealth(clientCtx.Config.Addr, clientNodeID); !errors.Is(err, ErrNotHeartbeated) {
 		t.Errorf("wanted ErrNotHeartbeated, not %v", err)

--- a/pkg/rpc/nodedialer/nodedialer_test.go
+++ b/pkg/rpc/nodedialer/nodedialer_test.go
@@ -235,7 +235,7 @@ func TestConnHealthInternal(t *testing.T) {
 	// Set up an internal server and relevant configuration. The RPC connection
 	// will then be considered internal, and we don't have to dial it.
 	rpcCtx := newTestContext(clock, stopper)
-	rpcCtx.SetLocalInternalServer(&internalServer{})
+	rpcCtx.SetLocalInternalServer(&internalServer{}, rpc.ServerInterceptorInfo{})
 	rpcCtx.NodeID.Set(ctx, staticNodeID)
 	rpcCtx.Config.AdvertiseAddr = localAddr.String()
 

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -26,15 +26,19 @@ import (
 // RPCs.
 type grpcServer struct {
 	*grpc.Server
-	mode serveMode
+	serverInterceptorsInfo rpc.ServerInterceptorInfo
+	mode                   serveMode
 }
 
 func newGRPCServer(rpcCtx *rpc.Context) *grpcServer {
 	s := &grpcServer{}
 	s.mode.set(modeInitializing)
-	s.Server = rpc.NewServer(rpcCtx, rpc.WithInterceptor(func(path string) error {
-		return s.intercept(path)
-	}))
+	srv, interceptorInfo := rpc.NewServerEx(
+		rpcCtx, rpc.WithInterceptor(func(path string) error {
+			return s.intercept(path)
+		}))
+	s.Server = srv
+	s.serverInterceptorsInfo = interceptorInfo
 	return s
 }
 

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -943,32 +943,28 @@ func (n *Node) batchInternal(
 	}
 
 	var br *roachpb.BatchResponse
-	if err := n.stopper.RunTaskWithErr(ctx, "node.Node: batch", func(ctx context.Context) error {
-		var finishSpan func(context.Context, *roachpb.BatchResponse)
-		// Shadow ctx from the outer function. Written like this to pass the linter.
-		ctx, finishSpan = n.setupSpanForIncomingRPC(ctx, tenID, args)
-		// NB: wrapped to delay br evaluation to its value when returning.
-		defer func() { finishSpan(ctx, br) }()
-		if log.HasSpanOrEvent(ctx) {
-			log.Eventf(ctx, "node received request: %s", args.Summary())
-		}
-
-		tStart := timeutil.Now()
-		var pErr *roachpb.Error
-		br, pErr = n.stores.Send(ctx, *args)
-		if pErr != nil {
-			br = &roachpb.BatchResponse{}
-			log.VErrEventf(ctx, 3, "error from stores.Send: %s", pErr)
-		}
-		if br.Error != nil {
-			panic(roachpb.ErrorUnexpectedlySet(n.stores, br))
-		}
-		n.metrics.callComplete(timeutil.Since(tStart), pErr)
-		br.Error = pErr
-		return nil
-	}); err != nil {
-		return nil, err
+	var finishSpan func(context.Context, *roachpb.BatchResponse)
+	// Shadow ctx from the outer function. Written like this to pass the linter.
+	ctx, finishSpan = n.setupSpanForIncomingRPC(ctx, tenID, args)
+	// NB: wrapped to delay br evaluation to its value when returning.
+	defer func() { finishSpan(ctx, br) }()
+	if log.HasSpanOrEvent(ctx) {
+		log.Eventf(ctx, "node received request: %s", args.Summary())
 	}
+
+	tStart := timeutil.Now()
+	var pErr *roachpb.Error
+	br, pErr = n.stores.Send(ctx, *args)
+	if pErr != nil {
+		br = &roachpb.BatchResponse{}
+		log.VErrEventf(ctx, 3, "error from stores.Send: %s", pErr)
+	}
+	if br.Error != nil {
+		panic(roachpb.ErrorUnexpectedlySet(n.stores, br))
+	}
+	n.metrics.callComplete(timeutil.Since(tStart), pErr)
+	br.Error = pErr
+
 	return br, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -887,7 +887,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 
 	// Connect the node as loopback handler for RPC requests to the
 	// local node.
-	s.rpcContext.SetLocalInternalServer(s.node)
+	s.rpcContext.SetLocalInternalServer(s.node, s.grpc.serverInterceptorsInfo)
 
 	// Load the TLS configuration for the HTTP server.
 	uiTLSConfig, err := s.rpcContext.GetUIServerTLSConfig()


### PR DESCRIPTION
Before this patch, the gRPC interceptors that we normally run on the
client and the server were not being run for "RPCs" to the "Internal"
sevice going to the local node. Such RPCs are done through the
localClientAdapter, which bypasses gRPC for performance reasons. Not
running these interceptors is bad - they do useful things around
creating tasks, tracing, etc. Also authentication/authorization,
although that interceptor in particular is not subject to this change.
Some of the things done by the interceptors was done separately and
redundantly in random places to account for the RPC local case.

This patch unifies the paths of local and remote RPCs by having the
localClientAdapter run server interceptors. The client interceptors
might come in a different patch. Care was taken to not introduce a
performance regression on the local path; in particular, there are no
new allocations.

As an exception, the Auth server interceptor is skipped on the local
path. As it stands, that interceptor refuses local RPCs in secure
clusters because it can't find TLS information in the ctx. I don't know
whether we should try to make this interceptor work or not.

Node.batchInternal was simplified slightly to not create a task, since
the interceptor now does it in all cases. Before, creating the task was
redundant in the non-local RPC case.

Touches #74732. That issue calls for both client and server interceptors
to be run; this patch only deals with server interceptors.

name                        old time/op    new time/op    delta
KV/Insert/Native/rows=1-32    88.0µs ± 4%    88.3µs ± 3%    ~     (p=1.000 n=5+5)
KV/Insert/SQL/rows=1-32        333µs ± 3%     322µs ± 3%    ~     (p=0.056 n=5+5)
KV/Update/Native/rows=1-32     111µs ± 3%     113µs ± 2%    ~     (p=0.095 n=5+5)
KV/Update/SQL/rows=1-32        437µs ± 4%     435µs ± 3%    ~     (p=0.841 n=5+5)
KV/Delete/Native/rows=1-32    92.2µs ±12%    88.5µs ± 5%    ~     (p=0.421 n=5+5)
KV/Delete/SQL/rows=1-32        260µs ±13%     285µs ±17%    ~     (p=0.151 n=5+5)
KV/Scan/Native/rows=1-32      18.9µs ± 2%    19.2µs ± 2%    ~     (p=0.151 n=5+5)
KV/Scan/SQL/rows=1-32          203µs ±10%     206µs ± 6%    ~     (p=0.841 n=5+5)

name                        old alloc/op   new alloc/op   delta
KV/Insert/Native/rows=1-32    15.2kB ± 0%    15.3kB ± 2%    ~     (p=1.000 n=5+5)
KV/Insert/SQL/rows=1-32       40.2kB ± 0%    40.0kB ± 1%    ~     (p=0.151 n=5+5)
KV/Update/Native/rows=1-32    20.7kB ± 0%    20.8kB ± 1%  +0.70%  (p=0.008 n=5+5)
KV/Update/SQL/rows=1-32       46.3kB ± 0%    46.6kB ± 0%  +0.56%  (p=0.032 n=5+5)
KV/Delete/Native/rows=1-32    14.8kB ± 1%    14.8kB ± 1%    ~     (p=0.841 n=5+5)
KV/Delete/SQL/rows=1-32       41.5kB ± 1%    41.9kB ± 2%    ~     (p=0.310 n=5+5)
KV/Scan/Native/rows=1-32      6.96kB ± 0%    6.95kB ± 1%    ~     (p=0.905 n=5+5)
KV/Scan/SQL/rows=1-32         18.6kB ± 0%    18.6kB ± 0%    ~     (p=0.841 n=5+5)

name                        old allocs/op  new allocs/op  delta
KV/Insert/Native/rows=1-32       118 ± 0%       119 ± 4%    ~     (p=0.556 n=4+5)
KV/Insert/SQL/rows=1-32          331 ± 0%       330 ± 0%    ~     (p=0.286 n=5+5)
KV/Update/Native/rows=1-32       164 ± 0%       164 ± 0%    ~     (all equal)
KV/Update/SQL/rows=1-32          481 ± 0%       482 ± 0%    ~     (p=0.238 n=5+5)
KV/Delete/Native/rows=1-32       118 ± 1%       117 ± 1%    ~     (p=1.000 n=5+5)
KV/Delete/SQL/rows=1-32          307 ± 1%       308 ± 0%    ~     (p=0.238 n=5+4)
KV/Scan/Native/rows=1-32        49.0 ± 0%      49.0 ± 0%    ~     (all equal)
KV/Scan/SQL/rows=1-32            229 ± 0%       229 ± 0%    ~     (p=0.556 n=4+5)

Release note: None